### PR TITLE
PUT /transactions{id}

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -17,38 +17,38 @@ for source in [APP_ROUTES, DOC_ROUTES]:
 
 
 class SMSTransactionsController(BaseHTTPRequestHandler):
-    
+
     service = SMSTransactionsService()
-    
+
     def _match_route(self, method, path):
         routes = ROUTES.get(method, {})
-        
+
         if path in routes:
             return routes[path], {}
-        
+
         for route_pattern, handler in routes.items():
             if ':' in route_pattern:
                 # Convert route pattern to regex
                 # /transactions/:id -> /transactions/([^/]+)
                 regex_pattern = re.sub(r':(\w+)', r'([^/]+)', route_pattern)
                 regex_pattern = '^' + regex_pattern + '$'
-                
+
                 match = re.match(regex_pattern, path)
                 if match:
                     # Extract parameter names and values
                     param_names = re.findall(r':(\w+)', route_pattern)
                     params = dict(zip(param_names, match.groups()))
                     return handler, params
-        
+
         return None, {}
-    
+
     def _send_error_response(self, status_code, message):
         self.send_response(status_code)
         self.send_header('Content-type', 'application/json')
 
         if status_code == 401:
             self.send_header('WWW-Authenticate', 'Basic realm="Momo API"')
-        
+
         self.end_headers()
         response = {"error": message}
         self.wfile.write(json.dumps(response).encode())
@@ -56,7 +56,7 @@ class SMSTransactionsController(BaseHTTPRequestHandler):
     def do_GET(self):
         """Handle GET requests"""
         path = urlparse(self.path).path
-        
+
         handler_func, params = self._match_route('GET', path)
         if handler_func:
             if params:
@@ -65,10 +65,10 @@ class SMSTransactionsController(BaseHTTPRequestHandler):
                 handler_func(self)
         else:
             self._send_error_response(404, "Route not found")
-    
+
     def do_POST(self):
         path = urlparse(self.path).path
-        
+
         handler_func, params = self._match_route('POST', path)
         if handler_func:
             if params:
@@ -77,10 +77,23 @@ class SMSTransactionsController(BaseHTTPRequestHandler):
                 handler_func(self)
         else:
             self._send_error_response(404, "Route not found")
-    
+
+    def do_PUT(self):
+        """Handle PUT requests"""
+        path = urlparse(self.path).path
+
+        handler_func, params = self._match_route('PUT', path)
+        if handler_func:
+            if params:
+                handler_func(self, **params)
+            else:
+                handler_func(self)
+        else:
+            self._send_error_response(404, "Route not found")
+
     def do_DELETE(self):
         path = urlparse(self.path).path
-        
+
         handler_func, params = self._match_route('DELETE', path)
         if handler_func:
             if params:

--- a/api/controller.py
+++ b/api/controller.py
@@ -79,7 +79,6 @@ class SMSTransactionsController(BaseHTTPRequestHandler):
             self._send_error_response(404, "Route not found")
 
     def do_PUT(self):
-        """Handle PUT requests"""
         path = urlparse(self.path).path
 
         handler_func, params = self._match_route('PUT', path)

--- a/api/docs.py
+++ b/api/docs.py
@@ -319,6 +319,77 @@ def _doc_create_transaction():
 
 @api_router.route(
     path="/transactions/{id}",
+    methods=["PUT"],
+    summary="Update a transaction",
+    description="Update an existing SMS transaction by its transaction ID. You can update sender, type, amount_rwf, from, and phone fields. Balances are automatically recalculated if amount or type changes.",
+    require_auth=True,
+    parameters=[
+        {
+            "name": "id",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "integer"},
+            "description": "Transaction ID to update"
+        }
+    ],
+    responses={
+        "200": {
+            "description": "Transaction updated successfully",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "status": {"type": "string"},
+                            "message": {"type": "string"},
+                            "data": {
+                                "type": "object",
+                                "properties": {
+                                    "transaction_id": {"type": "integer"},
+                                    "sender": {"type": "string"},
+                                    "type": {"type": "string"},
+                                    "amount_rwf": {"type": "number"},
+                                    "from": {"type": "string"},
+                                    "phone_masked": {"type": "string"},
+                                    "date": {"type": "string"},
+                                    "readable_date": {"type": "string"},
+                                    "balance_rwf": {"type": "number"}
+                                }
+                            }
+                        }
+                    },
+                    "example": {
+                        "status": "success",
+                        "message": "Transaction updated successfully",
+                        "data": {
+                            "transaction_id": 1,
+                            "sender": "Airtel",
+                            "type": "sent",
+                            "amount_rwf": 2000,
+                            "from": "Jane Smith",
+                            "phone_masked": "*******789",
+                            "date": "2026-01-24T10:30:00",
+                            "readable_date": "24 Jan 2026 10:30:00 AM",
+                            "balance_rwf": 3000
+                        }
+                    }
+                }
+            }
+        },
+        "400": error_response("Bad request - Validation error or insufficient funds",
+                              {"error": "Bad Request: Invalid transaction data or insufficient funds"}),
+        "401": error_response("Unauthorized", {"error": "Unauthorized: Invalid or missing credentials"}),
+        "404": error_response("Not found", {"error": "Not Found: Transaction with ID 1 does not exist"}),
+        "500": error_response("Internal server error", {"error": "Internal Server Error: Could not update transaction"})
+    },
+    tags=["Transactions"]
+)
+def _doc_update_transaction():
+    pass
+
+
+@api_router.route(
+    path="/transactions/{id}",
     methods=["DELETE"],
     summary="Delete a transaction",
     description="Remove a transaction from the system by its transaction ID",

--- a/api/routes.py
+++ b/api/routes.py
@@ -125,6 +125,41 @@ def get_transaction_by_id(handler):
     })
 
 
+def update_transaction(handler, id):
+    service = handler.service
+
+    if not service.is_authenticated(handler.headers):
+        service.response(handler, 401, {
+            "error": "Unauthorized: Invalid or missing credentials"
+        })
+        return
+
+    is_valid, error, data = service.validate_create_transaction_request(
+        handler.headers,
+        handler.rfile
+    )
+
+    if not is_valid:
+        service.response(handler, 400, {"error": error})
+        return
+
+    success, error, updated_transaction = service.update_transaction(id, data)
+    if not success:
+        if "Not Found" in error:
+            service.response(handler, 404, {"error": error})
+        elif "Bad Request" in error:
+            service.response(handler, 400, {"error": error})
+        else:
+            service.response(handler, 500, {"error": error})
+        return
+
+    service.response(handler, 200, {
+        "status": "success",
+        "message": "Transaction updated successfully",
+        "data": updated_transaction
+    })
+
+
 def delete_transaction(handler, id):
     service = handler.service
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -196,6 +196,9 @@ ROUTES = {
         "/transactions": create_transaction,
         "/one-time-data-parser": handle_data_parser,
     },
+    "PUT": {
+        "/transactions/:id": update_transaction,
+    },
     "DELETE": {
         "/transactions/:id": delete_transaction,
     }

--- a/api/service.py
+++ b/api/service.py
@@ -147,7 +147,6 @@ class SMSTransactionsService:
             return False, "Internal Server Error: Could not save transaction"
 
     def update_transaction(self, transaction_id, data):
-        """Update an existing transaction with new data"""
         try:
             target_id = int(transaction_id)
         except (ValueError, TypeError):

--- a/api/service.py
+++ b/api/service.py
@@ -34,19 +34,20 @@ class SMSTransactionsService:
             return False, "Bad Request: Could not read content", None
 
         required_fields = ["sender", "type", "amount_rwf", "from", "phone"]
-        missing_fields = [field for field in required_fields if field not in data]
-        
+        missing_fields = [
+            field for field in required_fields if field not in data]
+
         if missing_fields:
-             return False, f"Bad Request: Missing required fields ({', '.join(missing_fields)})", None
-        
+            return False, f"Bad Request: Missing required fields ({', '.join(missing_fields)})", None
+
         # Validate type
         if data["type"] not in ["received", "sent"]:
             return False, "Bad Request: type must be 'received' or 'sent'", None
-            
+
         # Validate amount
         if not isinstance(data["amount_rwf"], (int, float)) or data["amount_rwf"] <= 0:
             return False, "Bad Request: amount_rwf must be a positive number", None
-            
+
         return True, None, data
 
     def read_transactions(self):
@@ -93,7 +94,7 @@ class SMSTransactionsService:
 
     def write_transaction(self, data):
         transactions = self.read_transactions()
-        
+
         # 1. Mask phone number
         raw_phone = str(data.get("phone", ""))
         if len(raw_phone) > 3:
@@ -101,26 +102,26 @@ class SMSTransactionsService:
         else:
             masked_phone = raw_phone
         data["phone_masked"] = masked_phone
-        
+
         # 2. Generate transaction_id
         data["transaction_id"] = self.generate_transaction_id(transactions)
-        
+
         # 3. Date and readable_date
         now = datetime.now()
         data["date"] = now.strftime("%Y-%m-%dT%H:%M:%S")
         # example: "10 May 2024 4:30:58 PM"
         data["readable_date"] = now.strftime("%d %b %Y %I:%M:%S %p")
-        
+
         # 4. Calculate balance
         current_balance = 0
         if transactions:
             # Assuming the list is ordered by time
             last_item = transactions[-1]
             current_balance = last_item.get("balance_rwf", 0)
-            
+
         amount = data["amount_rwf"]
         transaction_type = data["type"]
-        
+
         if transaction_type == "received":
             new_balance = current_balance + amount
         elif transaction_type == "sent":
@@ -129,21 +130,118 @@ class SMSTransactionsService:
             new_balance = current_balance - amount
         else:
             return False, "Bad Request: Invalid transaction type"
-            
+
         data["balance_rwf"] = new_balance
-        
+
         # Remove original 'phone' field because we will only store the phone_masked
         if "phone" in data:
             del data["phone"]
 
         transactions.append(data)
-        
+
         try:
             with open(self.DATA_FILE, 'w') as f:
                 json.dump(transactions, f, indent=4)
             return True, None
         except IOError:
             return False, "Internal Server Error: Could not save transaction"
+
+    def update_transaction(self, transaction_id, data):
+        """Update an existing transaction with new data"""
+        try:
+            target_id = int(transaction_id)
+        except (ValueError, TypeError):
+            return False, "Bad Request: Invalid transaction ID format", None
+
+        transactions = self.read_transactions()
+
+        # Find the transaction to update
+        transaction_index = None
+        for idx, t in enumerate(transactions):
+            if t.get("transaction_id") == target_id:
+                transaction_index = idx
+                break
+
+        if transaction_index is None:
+            return False, f"Not Found: Transaction with ID {target_id} does not exist", None
+
+        # Validate updatable fields
+        updatable_fields = ["sender", "type", "amount_rwf", "from", "phone"]
+        update_data = {}
+
+        for field in updatable_fields:
+            if field in data:
+                update_data[field] = data[field]
+
+        # Validate type if provided
+        if "type" in update_data and update_data["type"] not in ["received", "sent"]:
+            return False, "Bad Request: type must be 'received' or 'sent'", None
+
+        # Validate amount if provided
+        if "amount_rwf" in update_data:
+            if not isinstance(update_data["amount_rwf"], (int, float)) or update_data["amount_rwf"] <= 0:
+                return False, "Bad Request: amount_rwf must be a positive number", None
+
+        # Get the current transaction
+        current_transaction = transactions[transaction_index]
+
+        # Update phone mask if phone is updated
+        if "phone" in update_data:
+            raw_phone = str(update_data["phone"])
+            if len(raw_phone) > 3:
+                masked_phone = "*" * (len(raw_phone) - 3) + raw_phone[-3:]
+            else:
+                masked_phone = raw_phone
+            current_transaction["phone_masked"] = masked_phone
+            del update_data["phone"]
+
+        # Update simple fields
+        for field in ["sender", "type", "from", "amount_rwf"]:
+            if field in update_data:
+                current_transaction[field] = update_data[field]
+
+        # If amount or type changed, recalculate balance
+        if "amount_rwf" in update_data or "type" in update_data:
+            # Recalculate balance from the beginning
+            new_balance = 0
+            for idx, transaction in enumerate(transactions):
+                if idx < transaction_index:
+                    # Keep existing balances before the updated transaction
+                    new_balance = transaction.get("balance_rwf", 0)
+                elif idx == transaction_index:
+                    # Calculate new balance for updated transaction
+                    amount = current_transaction.get("amount_rwf", 0)
+                    trans_type = current_transaction.get("type", "received")
+
+                    if trans_type == "received":
+                        new_balance = new_balance + amount
+                    elif trans_type == "sent":
+                        if new_balance < amount:
+                            return False, f"Bad Request: Insufficient funds for this transaction. Available balance: {new_balance}", None
+                        new_balance = new_balance - amount
+
+                    current_transaction["balance_rwf"] = new_balance
+                else:
+                    # Recalculate all balances after the updated transaction
+                    amount = transaction.get("amount_rwf", 0)
+                    trans_type = transaction.get("type", "received")
+
+                    if trans_type == "received":
+                        new_balance = new_balance + amount
+                    elif trans_type == "sent":
+                        new_balance = new_balance - amount
+
+                    transaction["balance_rwf"] = new_balance
+
+        # Update the transaction in the list
+        transactions[transaction_index] = current_transaction
+
+        try:
+            with open(self.DATA_FILE, 'w') as f:
+                json.dump(transactions, f, indent=4)
+            return True, None, current_transaction
+        except IOError:
+            return False, "Internal Server Error: Could not update transaction", None
 
     def delete_transaction(self, transaction_id):
         transactions = self.read_transactions()
@@ -170,9 +268,9 @@ class SMSTransactionsService:
     def response(self, handler, status_code, data):
         handler.send_response(status_code)
         handler.send_header('Content-type', 'application/json')
-        
+
         if status_code == 401:
             handler.send_header('WWW-Authenticate', 'Basic realm="Momo API"')
-            
+
         handler.end_headers()
         handler.wfile.write(json.dumps(data).encode())

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -1,10 +1,12 @@
 # API Docs
 
 ### POST `/transactions`
+
 <details>
 <summary>Click to expand</summary>
 
 When making the POST request you have to provide a JSON object that looks like this:
+
 ```json
 {
   "sender": "name (string)",
@@ -16,21 +18,22 @@ When making the POST request you have to provide a JSON object that looks like t
 ```
 
 If the request is succesful you will receive a JSON response object:
+
 ```json
 {
-    "status": "success",
-    "message": "Transaction created successfully",
-    "data": {
-        "sender": "M-Money",
-        "amount_rwf": 10000,
-        "type": "received",
-        "from": "Kevin Rebakure",
-        "phone_masked": "*******630",
-        "transaction_id": 4,
-        "date": "2026-01-26T08:39:04",
-        "readable_date": "26 Jan 2026 08:39:04 AM",
-        "balance_rwf": 40000
-    }
+  "status": "success",
+  "message": "Transaction created successfully",
+  "data": {
+    "sender": "M-Money",
+    "amount_rwf": 10000,
+    "type": "received",
+    "from": "Kevin Rebakure",
+    "phone_masked": "*******630",
+    "transaction_id": 4,
+    "date": "2026-01-26T08:39:04",
+    "readable_date": "26 Jan 2026 08:39:04 AM",
+    "balance_rwf": 40000
+  }
 }
 ```
 
@@ -38,15 +41,17 @@ If the request is succesful you will receive a JSON response object:
 - The balance is calculated. When you send money, the balance will be reduced and when you receive money the balance will be increased.
 - You will receive a `201 CREATED` status code
 - Validation errors will be represented with this JSON object
+
 ```json
-    {
-        "error": "Bad Request: Missing required fields (from, phone)"
-    }
+{
+  "error": "Bad Request: Missing required fields (from, phone)"
+}
 ```
 
 </details>
 
 ### GET `/transactions` and `/transactions/{id}`
+
 <details>
 <summary>Click to expand</summary>
 
@@ -54,15 +59,70 @@ If the request is succesful you will receive a JSON response object:
 
 </details>
 
-### PATCH `/transactions/{id}`
+### PUT `/transactions/{id}`
+
 <details>
 <summary>Click to expand</summary>
 
-[Victor - Documentation]
+Updates an existing transaction by its transaction ID. You can update any of these fields: `sender`, `type`, `amount_rwf`, `from`, and `phone`. If you change the amount or type, the running balance will be automatically recalculated.
+
+When making the PUT request, provide a JSON object with the fields you want to update:
+
+```json
+{
+  "sender": "Airtel",
+  "amount_rwf": 2000,
+  "type": "sent",
+  "from": "Jane Smith",
+  "phone": "0987654321"
+}
+```
+
+If the request is successful, you will receive a JSON response object:
+
+```json
+{
+  "status": "success",
+  "message": "Transaction updated successfully",
+  "data": {
+    "transaction_id": 1,
+    "sender": "Airtel",
+    "amount_rwf": 2000,
+    "type": "sent",
+    "from": "Jane Smith",
+    "phone_masked": "*******321",
+    "date": "2026-01-24T10:30:00",
+    "readable_date": "24 Jan 2026 10:30:00 AM",
+    "balance_rwf": 3000
+  }
+}
+```
+
+**Key Notes:**
+
+- You will receive a `200 OK` status code
+- The phone number is automatically masked for security
+- If you update the amount or type, the balance and all subsequent transaction balances are recalculated
+- If you try to send more money than available balance, you'll get a validation error
+- Validation errors will be represented with this JSON object:
+
+```json
+{
+  "error": "Bad Request: Invalid transaction data"
+}
+```
+
+**Possible Error Responses:**
+
+- `400 Bad Request`: Invalid data format or insufficient funds
+- `401 Unauthorized`: Invalid or missing credentials
+- `404 Not Found`: Transaction ID does not exist
+- `500 Internal Server Error`: Server error while updating
 
 </details>
 
 ### DELETE `/transactions/{id}`
+
 <details>
 <summary>Click to expand</summary>
 
@@ -71,11 +131,13 @@ If the request is succesful you will receive a JSON response object:
 </details>
 
 ### POST `/one-time-data-parser`
+
 <details>
 <summary>Click to expand</summary>
 
-- Converts XML data from `app/assets/modified_sms_v2.xml` to JSON format. 
+- Converts XML data from `app/assets/modified_sms_v2.xml` to JSON format.
 - ⚠️ **IMPORTANT:** This endpoint can only be called **once** successfully. Subsequent calls will return an error.
+
 ```json
 {
   "success": true,
@@ -108,6 +170,7 @@ If the request is succesful you will receive a JSON response object:
 </details>
 
 ### GET `/api-docs`
+
 <details>
 <summary>Click to expand</summary>
 
@@ -117,6 +180,7 @@ If the request is succesful you will receive a JSON response object:
 </details>
 
 ### GET `/openapi.json`
+
 <details>
 <summary>Click to expand</summary>
 


### PR DESCRIPTION
- Implements PUT `/transactions/{id}` endpoint to update existing transactions with automatic balance recalculation
- Validates all input data and prevents insufficient funds errors when modifying transaction amounts or types
- Automatically masks phone numbers and recalculates running balances for all subsequent transactions when an earlier transaction is modified
- Added comprehensive documentation: OpenAPI/Swagger spec + markdown guide with request/response examples and error scenarios
- Includes controller support for PUT requests and follows atomic commits with conventional commit messages